### PR TITLE
未ログイン時に記事一覧ページが表示されるよう修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  skip_before_action :require_login, only: [:index, :show]
+  
   def index
     @posts = Post.includes(:post_details).where(status: 1).order(created_at: :desc)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,8 +9,9 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       redirect_to root_path, success: t('.success')
-    else
-      render :new, status: :unprocessable_entity, success: t('.failure')
+    else 
+      flash.now[:danger] = t('.failure')
+      render :new, status: :unprocessable_entity, success: 
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,12 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  validates :name, presence: true, uniqueness: true, length: { in: 3..20 }
+  validates :email, presence: true, uniqueness: true
   validates :password, length: { in: 8..20 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
-  validates :email, presence: true, uniqueness: true
   validates :reset_password_token, presence: true, uniqueness: true, allow_nil: true
-  validates :name, presence: true, uniqueness: true, length: { in: 3..20 }
 
   has_many :posts, dependent: :destroy
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,9 @@
   <head>
     <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="turbo-visit-control" content="reload">
+    <% if controller.controller_name == 'posts' && controller.action_name == 'show' %>
+      <meta name="turbo-visit-control" content="reload">
+    <% end %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= favicon_link_tag('favicon.ico') %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,11 +11,6 @@
         <li class="list-inline-item me-auto">
           <h3 style="display: inline;" class="fw-bold"><%= @post.title %></h3>
         </li>
-        <% if current_user.own?(@post) %>
-          <li class="list-inline-item">
-            <%= link_to "削除", post_path(@post), class: "btn btn-danger", id: "button-delete", data: { turbo_method: :delete, turbo_confirm: '記事を削除します。よろしいですか？' } %>
-          </li>
-        <% end %>
       </ul>
       <ul class="list-inline">
         <li class="list-inline-item"><%= "by #{@post.user.name}" %></li>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,4 +1,4 @@
-<% if object.errors.any? %>
+<% if object && object.errors.any? %>
   <div id="error_explanation" class="alert alert-danger">
     <ul class="mb-0">
       <% object.errors.each do |error| %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -3,7 +3,8 @@
   <div class="row">
     <div class=" col-md-10 col-lg-8 mx-auto">
       <p class="fs-3 text-center fw-bold"><%= t('.title') %></p>
-      <%= form_with url: login_path do |f| %>
+      <%= form_with url: login_path, model: @user, local: false do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
         <div class="mb-3">
           <%= f.label :email %>
           <%= f.email_field :email, class: "form-control" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,21 +3,22 @@
   <div class="row">
     <div class=" col-md-10 col-lg-8 mx-auto">
       <p class="fs-3 text-center fw-bold"><%= t('.title') %></p>
-      <%= form_with model: @user do |f| %>
+      <%= form_with model: @user, local: false do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
         <div class="mb-3">
-          <%= f.label :name, class: "form-label" %>
+          <%= f.label :name, "ユーザー名 [必須]", class: "form-label" %>
           <%= f.text_field :name, class: "form-control" %>
         </div>
         <div class="mb-3">
-          <%= f.label :email, class: "form-label" %>
+          <%= f.label :email, "メールアドレス [必須]", class: "form-label" %>
           <%= f.email_field :email, class: "form-control" %>
         </div>
         <div class="mb-3">
-          <%= f.label :password, class: "form-label" %>
+          <%= f.label :password, "パスワード [必須]", class: "form-label" %>
           <%= f.password_field :password, class: "form-control" %>
         </div>
         <div class="mb-3">
-          <%= f.label :password_confirmation, class: "form-label" %>
+          <%= f.label :password_confirmation, "パスワード確認 [必須]", class: "form-label" %>
           <%= f.password_field :password_confirmation, class: "form-control" %>
         </div>
         <div class="d-grid gap-2">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,4 +1,9 @@
-<h2>Hello World</h2>
-<p>
-  The time is now: <%= Time.now %>
-</p>
+<% content_for(:title, "") %>
+<div class="container pt-3">
+  <div class="row">
+    <div class="d-flex align-items-center">
+      <p class="fw-bold">1日の行動を記録しよう</p>
+      <%= image_tag "Allura - In The Park.png" %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
# 概要
未ログイン時に記事一覧ページが表示されるよう修正

## 詳細
・以下metaタグがposts#show実行時にのみheadタグに挿入されるように修正(他画面で入力時にバリデーションエラーが表示されなくなるため)
`<meta name="turbo-visit-control" content="reload">`
・未ログイン時に記事一覧、記事詳細が閲覧できるように修正